### PR TITLE
Fix docs feature pluralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 
 To learn more about Next.js, take a look at the following resources:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and APIs.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!


### PR DESCRIPTION
## Summary
- fix grammar in README about Next.js features and APIs

## Testing
- `node -e "console.log('test')"`
